### PR TITLE
Es format sign before symbol

### DIFF
--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -187,12 +187,18 @@ class Money
           :after
         end
 
+      sign = ""
+      if rules[:sign_before_symbol] == true && self.negative?
+        formatted.tr!("-", "")
+        sign = "-"
+      end
+
       if symbol_value && !symbol_value.empty?
         formatted = if symbol_position == :before
-          "#{symbol_value}#{formatted}"
+          "#{sign}#{symbol_value}#{formatted}"
         else
           symbol_space = rules[:symbol_after_without_space] ? "" : " "
-          "#{formatted}#{symbol_space}#{symbol_value}"
+          "#{sign}#{formatted}#{symbol_space}#{symbol_value}"
         end
       end
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -343,6 +343,17 @@ describe Money, "formatting" do
       end
     end
 
+    describe ":sign_before_symbol option" do
+      specify "(:sign_before_symbol => true) works as documented" do
+        Money.us_dollar(-100000).format(:sign_before_symbol => true).should == "-$1,000.00"
+      end
+
+      specify "(:sign_before_symbol => false) works as documented" do
+        Money.us_dollar(-100000).format(:sign_before_symbol => false).should == "$-1,000.00"
+        Money.us_dollar(-100000).format(:sign_before_symbol => nil).should == "$-1,000.00"
+      end
+    end
+
     context "when the monetary value is 0" do
       let(:money) { Money.us_dollar(0) }
 


### PR DESCRIPTION
Added option to money to format the "-" sign before the currency symbol

Note, this is for ticket: https://noths.lighthouseapp.com/projects/84022-bugs/tickets/1468-negative-symbol-on-currency
