### PR TITLE
[#85077910] Update I18n dependency to be Rails 4.2 compatible

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 1.9.2"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "i18n",       "~> 0.6.0"
+  s.add_dependency "i18n",       "~> 0.7.0"
 
   s.add_development_dependency "rspec",       "~> 2.10.0"
   s.add_development_dependency "yard",        "~> 0.8.1"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'rspec'
 require 'money'
 
+I18n.enforce_available_locales = false
+
 RSpec.configure do |c|
   c.order = "rand"
 end


### PR DESCRIPTION
- Updated money gem to be dependent on i18n (0.7.0)
  to be compatible with Rails 4.2, which depends on
  i18n (0.7.0)

https://www.pivotaltracker.com/story/show/85077910
