### PR TITLE
[#85077910] Use correct version of i18n for Rails 4.2

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 1.9.2"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "i18n",       "~> 0.7.0"
+  s.add_dependency "i18n",       "~> 0.6"
 
   s.add_development_dependency "rspec",       "~> 2.10.0"
   s.add_development_dependency "yard",        "~> 0.8.1"


### PR DESCRIPTION
Update version of "i18n" dependency
Current version of "i18n"   "~> 0.7.0" is too strict. 
Update i18n for wider range of minor versions change.
